### PR TITLE
teach CI how to create GitHub Releases and publish assets there

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.22
+  aws-cli: circleci/aws-cli@1.4.0
   buildevents: honeycombio/buildevents@0.2.7
 
 # enable a job when tag created (tag create is ignored by default)
@@ -46,6 +46,26 @@ commands:
       - buildevents/berun:
           bename: lint
           becommand: make lint
+  install_ghr:
+    steps:
+      - run:
+          name: Install ghr for drafting GitHub Releases
+          command: go get github.com/tcnksm/ghr
+  build_packages:
+    steps:
+      - buildevents/berun:
+          bename: build_packages
+          becommand: make package
+  draft_github_release:
+    steps:
+      - buildevents/berun:
+          bename: draft_github_release
+          becommand: make publish_github
+  sync_s3_artifacts:
+    steps:
+      - buildevents/berun:
+          bename: sync_s3_artifacts
+          becommand: make publish_s
 
 jobs:
   setup:
@@ -70,36 +90,19 @@ jobs:
             - persist_to_workspace:
                 root: .
                 paths: [ . ]
-  package:
-    executor: go
-    steps:
-      - buildevents/with_job_span:
-          steps:
-            - checkout
-            - buildevents/berun:
-                bename: packaging
-                becommand: make package
-            - persist_to_workspace:
-                root: .
-                paths: [ . ]
   release:
     executor: go
     steps:
       - buildevents/with_job_span:
           steps:
+            - install_ghr
+            - aws-cli/install
+            - aws-cli/setup
             - attach_workspace:
                 at: .
-            - buildevents/berun:
-                bename: native-deps
-                becommand: sudo apt update && sudo apt install python-is-python3 python3-pip
-            - aws-cli/setup:
-                aws-access-key-id: AWS_ACCESS_KEY_ID
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-                aws-region: AWS_REGION
-            - restore_go_cache
-            - buildevents/berun:
-                bename: release
-                becommand: make release
+            - build_packages
+            - draft_github_release
+            - sync_s3_artifacts
 
 workflows:
   version: 2
@@ -116,13 +119,9 @@ workflows:
           <<: *filters_always
           requires:
             - setup
-      - package:
-          <<: *filters_always
-          requires:
-            - setup
       - release:
-          <<: *filters_publish
+          # <<: *filters_publish
+          <<: *filters_always # only for testing in PR
           context: Honeycomb Secrets for Public Repos
           requires:
             - build
-            - package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,18 @@ commands:
       - restore_cache:
           key: cache1-go-mod-{{ checksum "go.sum" }}
 
+  build:
+    steps:
+      - buildevents/berun:
+          bename: build
+          becommand: make
+
+  lint:
+    steps:
+      - buildevents/berun:
+          bename: lint
+          becommand: make lint
+
 jobs:
   setup:
     executor: go
@@ -53,15 +65,9 @@ jobs:
       - buildevents/with_job_span:
           steps:
             - checkout
-            - buildevents/berun:
-                bename: build
-                becommand: make
-            - buildevents/berun:
-                bename: lint
-                becommand: make lint
-            # - buildevents/berun:
-            #     bename: test
-            #     becommand: make test
+            - build
+            - lint
+            # - test
             - save_go_cache
             - persist_to_workspace:
                 root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,18 +32,15 @@ commands:
           key: cache1-go-mod-{{ checksum "go.sum" }}
           paths:
             - go/pkg/mod
-
   restore_go_cache:
     steps:
       - restore_cache:
           key: cache1-go-mod-{{ checksum "go.sum" }}
-
   build:
     steps:
       - buildevents/berun:
           bename: build
           becommand: make
-
   lint:
     steps:
       - buildevents/berun:
@@ -64,6 +61,7 @@ jobs:
     steps:
       - buildevents/with_job_span:
           steps:
+            - buildevents/start_trace
             - checkout
             - build
             - lint
@@ -72,7 +70,18 @@ jobs:
             - persist_to_workspace:
                 root: .
                 paths: [ . ]
-
+  package:
+    executor: go
+    steps:
+      - buildevents/with_job_span:
+          steps:
+            - checkout
+            - buildevents/berun:
+                bename: packaging
+                becommand: make package
+            - persist_to_workspace:
+                root: .
+                paths: [ . ]
   release:
     executor: go
     steps:
@@ -88,9 +97,6 @@ jobs:
                 aws-secret-access-key: AWS_SECRET_ACCESS_KEY
                 aws-region: AWS_REGION
             - restore_go_cache
-            - buildevents/berun:
-                bename: package
-                becommand: make package
             - buildevents/berun:
                 bename: release
                 becommand: make release
@@ -110,8 +116,13 @@ workflows:
           <<: *filters_always
           requires:
             - setup
+      - package:
+          <<: *filters_always
+          requires:
+            - setup
       - release:
           <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
             - build
+            - package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,7 @@ workflows:
           requires:
             - setup
       - release:
-          # <<: *filters_publish
-          <<: *filters_always # only for testing in PR
+          <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,16 +26,6 @@ executors:
       - image: cimg/go:1.15.8
 
 commands:
-  save_go_cache:
-    steps:
-      - save_cache:
-          key: cache1-go-mod-{{ checksum "go.sum" }}
-          paths:
-            - go/pkg/mod
-  restore_go_cache:
-    steps:
-      - restore_cache:
-          key: cache1-go-mod-{{ checksum "go.sum" }}
   build:
     steps:
       - buildevents/berun:
@@ -46,11 +36,6 @@ commands:
       - buildevents/berun:
           bename: lint
           becommand: make lint
-  install_ghr:
-    steps:
-      - run:
-          name: Install ghr for drafting GitHub Releases
-          command: go get github.com/tcnksm/ghr
   build_packages:
     steps:
       - buildevents/berun:
@@ -65,7 +50,22 @@ commands:
     steps:
       - buildevents/berun:
           bename: sync_s3_artifacts
-          becommand: make publish_s
+          becommand: make publish_s3
+  save_go_cache:
+    steps:
+      - save_cache:
+          key: cache1-go-mod-{{ checksum "go.sum" }}
+          paths:
+            - go/pkg/mod
+  restore_go_cache:
+    steps:
+      - restore_cache:
+          key: cache1-go-mod-{{ checksum "go.sum" }}
+  install_ghr:
+    steps:
+      - run:
+          name: Install ghr for drafting GitHub Releases
+          command: go get github.com/tcnksm/ghr
 
 jobs:
   setup:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries for programs and plugins
 /influx2hny
+artifacts/
 dist/
 bin/
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,8 @@ CMD = influx2hny
 BIN = $(CURDIR)/bin
 GO_SOURCES := cmd/$(CMD)/main.go $(wildcard *.go) go.mod go.sum
 
-# default target: will get you a debug build in the top-level directory.
-# aliased as "make build"
 .PHONY: build
+#: default target: will get you a debug build in the top-level directory.
 build: $(CMD)
 $(CMD): $(GO_SOURCES)
 	go build -o $@ ./cmd/$(CMD)
@@ -20,35 +19,61 @@ $(CMD): $(GO_SOURCES)
 ### PACKAGE / RELEASE ###
 #########################
 
-PACKAGES = dist/linux_amd64 dist/linux_arm64
+# Which operating systems and architectures will we cross-compile for?
+# In the form of <os>-<arch>
+OSARCHS=\
+	linux-amd64   \
+	linux-arm64   \
 
-# package: each target in $PACKGAES built into a directory under dist/
+artifacts:
+	@mkdir -p artifacts
+
+# each item in OSARCHS appended to "artifacts/influx2hny-" to
+# generate the list of file paths for binaries to be cross-compiled
+BINARIES=$(OSARCHS:%=artifacts/$(CMD)-%)
+
+# these targets set OS and ARCH variables for any target that matches a path in $(BINARIES)
+# ex: "artifacts/influx2hny-linux-arm64"
+# 0: "artifacts/influx2hny"
+# 1: "linux"
+# 2: "arm64"
+# $* is the matched pattern, which is split on '-' to get the OS & ARCH values
+$(BINARIES): OS = $(word 1,$(subst -, ,$*))
+$(BINARIES): ARCH = $(word 2,$(subst -, ,$*))
+
+# builds the actual binary for each OS/ARCH listed in $OSARCHS
+$(BINARIES): artifacts/$(CMD)-%: artifacts
+	@echo "building: $@"
+	GOOS=$(OS) GOARCH=$(ARCH) \
+	  go build -trimpath \
+	           -ldflags "-s -w -X main.BuildVersion=$(RELEASE_VERSION)" \
+	           -o $@ \
+	           ./cmd/$(CMD)
+
+.PHONY: checksums
+checksums: artifacts/checksums.txt
+artifacts/checksums.txt: $(BINARIES)
+	@cd artifacts && shasum -a256 * > checksums.txt
+	@echo "checksums for builds saved to $@"
+
 .PHONY: package
-package: $(PACKAGES)
-$(PACKAGES): dist/% : dist/%/$(CMD) dist/%/$(CMD).sha256
-
-%.sha256: %
-	sha256sum $* > $@
+#: cross-compile for each OS and ARCH, find binaries and checksums in artifacts/
+package: $(BINARIES) checksums
 
 CIRCLE_TAG ?=
 RELEASE_VERSION ?= $(or $(CIRCLE_TAG), $(shell git rev-parse --short HEAD))
 RELEASE_BUCKET ?= honeycomb-builds
 
-# builds the actual binary for each OS/ARCH in $PACKAGES
-# this pattern matches something like /dist/linux_arm64/influx2hny
-# $* is the matched pattern, which is split on '_' to get the GOOS & GOARCH values
-dist/%/$(CMD): $(GO_SOURCES)
-	GOOS=$(word 1,$(subst _, ,$*)) GOARCH=$(word 2,$(subst _, ,$*)) go build -trimpath -ldflags "-s -w -X main.BuildVersion=$(RELEASE_VERSION)" -o $@ ./cmd/$(CMD)
-
 .PHONY: release
-release: $(PACKAGES)
-	aws s3 sync dist/ s3://$(RELEASE_BUCKET)/honeycombio/influx2hny/$(RELEASE_VERSION)
+release: package
+	aws s3 sync artifacts/ s3://$(RELEASE_BUCKET)/honeycombio/influx2hny/$(RELEASE_VERSION)
 
 ###############
 ### TOOLING ###
 ###############
 
 .PHONY: lint
+#: run the linter
 lint: $(BIN)/golangci-lint
 	$(BIN)/golangci-lint run ./...
 
@@ -59,6 +84,8 @@ $(BIN)/golangci-lint: $(BIN)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) v1.31.0
 
 .PHONY: clean
+#: clean up
 clean:
 	rm -f ./$(CMD)
 	rm -rf dist
+	rm -rf artifacts

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint: $(BIN)/golangci-lint
 	$(BIN)/golangci-lint run ./...
 
 #########################
-### PACKAGE / RELEASE ###
+###     PACKAGING     ###
 #########################
 
 # Which operating systems and architectures will we cross-compile for?
@@ -48,7 +48,7 @@ $(BINARIES): ARCH = $(word 2,$(subst -, ,$*))
 
 # builds the actual binary for each OS/ARCH listed in $OSARCHS
 $(BINARIES): artifacts/$(CMD)-%: artifacts
-	@echo "building: $@"
+	@echo "+++ building: $@"
 	GOOS=$(OS) GOARCH=$(ARCH) \
 	  go build -trimpath \
 	           -ldflags "-s -w -X main.BuildVersion=$(RELEASE_VERSION)" \
@@ -59,7 +59,7 @@ $(BINARIES): artifacts/$(CMD)-%: artifacts
 checksums: artifacts/checksums.txt
 artifacts/checksums.txt: $(BINARIES)
 	@cd artifacts && shasum -a256 * > checksums.txt
-	@echo "checksums for builds saved to $@"
+	@echo " * checksums for builds saved to $@"
 
 .PHONY: package
 #: cross-compile for each OS and ARCH, find binaries and checksums in artifacts/

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ publish_github: github_prereqs package
 	@echo "+++ publishing these assets to GitHub, tag $(RELEASE_VERSION)"
 	@ls -l artifacts/*
 	@cat artifacts/checksums.txt
-	@echo ghr -draft \
+	@ghr -draft \
 	     -name ${RELEASE_VERSION} \
 	     -token ${GITHUB_TOKEN} \
 	     -username ${CIRCLE_PROJECT_USERNAME} \
@@ -106,7 +106,7 @@ publish_s3: s3_prereqs package
 	@echo "+++ publishing these artfacts to $(RELEASE_BUCKET) bucket, version $(RELEASE_VERSION)"
 	@ls -l artifacts/*
 	@cat artifacts/checksums.txt
-	echo aws s3 sync artifacts/ s3://$(RELEASE_BUCKET)/honeycombio/influx2hny/$(RELEASE_VERSION)
+	@aws s3 sync artifacts/ s3://$(RELEASE_BUCKET)/honeycombio/influx2hny/$(RELEASE_VERSION)
 
 .PHONY: s3_prereqs
 s3_prereqs: awscli_present

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ package: $(BINARIES) checksums
 #########################
 
 CIRCLE_TAG ?=
-RELEASE_VERSION ?= $(or $(CIRCLE_TAG), $(shell git rev-parse --short HEAD))
+RELEASE_VERSION ?= $(or $(CIRCLE_TAG), $(shell git describe --tags))
 RELEASE_BUCKET ?= honeycomb-builds
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ build: $(CMD)
 $(CMD): $(GO_SOURCES)
 	go build -o $@ ./cmd/$(CMD)
 
+.PHONY: lint
+#: run the linter
+lint: $(BIN)/golangci-lint
+	$(BIN)/golangci-lint run ./...
+
 #########################
 ### PACKAGE / RELEASE ###
 #########################
@@ -71,11 +76,6 @@ release: package
 ###############
 ### TOOLING ###
 ###############
-
-.PHONY: lint
-#: run the linter
-lint: $(BIN)/golangci-lint
-	$(BIN)/golangci-lint run ./...
 
 $(BIN):
 	mkdir -p $@


### PR DESCRIPTION
influx2hny needs to get some automation applied.

- [x] collect the cross-compiled binaries into an `artifacts/` directory

This brings influx2hny releases over to the patterns used for target directory and binary names used by the other Honeycomb Go binary distributables.

Bonus! Adds [remake-style comment/documentation](https://remake.readthedocs.io/en/latest/features.html#listing-and-documenting-makefile-targets) ("#: blah blah") for targets that humans are most likely to be interested in.

Example output:

    » remake --tasks
    build                default target: will get you a debug build in the top-level directory.
    clean                clean up
    lint                 run the linter
    package              cross-compile for each OS and ARCH, find binaries and checksums in artifacts/

- [x] push the contents of `artifacts/` to a VERSION subdirectory in our builds bucket
- [x] publish a draft Release record in the GitHub repo for the tag
- [x] add the contents of `artifacts/` to the Release record as assets
