### PR TITLE
Fix GitHub publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ publish_github: github_prereqs package
 	     -repository ${CIRCLE_PROJECT_REPONAME} \
 	     -commitish ${CIRCLE_SHA1} \
 	     ${RELEASE_VERSION} \
-	     ~/artifacts
+	     artifacts/
 
 .PHONY: github_prereqs
 github_prereqs: ghr_present


### PR DESCRIPTION
## Which problem is this PR solving?

- Publishing the GitHub release fails due to an incorrect path specified

## Short description of the changes

- specifies the correct path to the artifacts

