### PR TITLE
[maint] fix release job in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,6 @@ jobs:
           steps:
             - buildevents/start_trace
             - checkout
-            - install_ghr
             - build
             # - lint
             # - test
@@ -101,9 +100,9 @@ jobs:
             - aws-cli/setup
             - attach_workspace:
                 at: .
-            - build_packages
-            - draft_github_release
-            - sync_s3_artifacts
+#            - build_packages
+#            - draft_github_release
+#            - sync_s3_artifacts
 
 workflows:
   version: 2
@@ -121,7 +120,8 @@ workflows:
           requires:
             - setup
       - release:
-          <<: *filters_publish
+#          <<: *filters_publish
+          <<: *filters_always
           context: Honeycomb Secrets for Public Repos
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
     steps:
       - run:
           name: Install ghr for drafting GitHub Releases
-          command: go install github.com/tcnksm/ghr
+          command: go install github.com/tcnksm/ghr@latest
 
 jobs:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,9 @@ jobs:
             - aws-cli/setup
             - attach_workspace:
                 at: .
-#            - build_packages
-#            - draft_github_release
-#            - sync_s3_artifacts
+            - build_packages
+            - draft_github_release
+            - sync_s3_artifacts
 
 workflows:
   version: 2
@@ -120,8 +120,7 @@ workflows:
           requires:
             - setup
       - release:
-#          <<: *filters_publish
-          <<: *filters_always
+          <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
     steps:
       - run:
           name: Install ghr for drafting GitHub Releases
-          command: go get github.com/tcnksm/ghr
+          command: go install github.com/tcnksm/ghr
 
 jobs:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
           steps:
             - buildevents/start_trace
             - checkout
+            - install_ghr
             - build
             # - lint
             # - test


### PR DESCRIPTION
Last release [failed](https://app.circleci.com/pipelines/github/honeycombio/influx2hny/108/workflows/8500099e-b48c-4c8c-8fbe-f66c42a532ca/jobs/318) in CI because `go get` in no longer valid in that context. Use `go install` instead.