### PR TITLE
chore: fix commit message prefix for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,5 @@ updates:
     reviewers:
       - "honeycombio/collection-team"
     commit-message:
-      prefix: "main"
+      prefix: "maint"
       include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

dependabots fail PR title status check (see #70 )

## Short description of the changes

update prefix from `main` to `maint` (oops)

## How to verify that this has the expected result

dependabot PRs shouldn't fail PR title status checks